### PR TITLE
Explicitly specify that the country field is a select element

### DIFF
--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for volunteer, url: '/#apply', method: :post do |f| %>
   <%= f.input :country,
+    as: :select,
     label: false,
     collection: countries,
     :selected => 'US'


### PR DESCRIPTION
Issue: #24 

This may be due to a quirk of the simple_form gem: heartcombo/simple_form#54

The fix could be to specify that this is a select element:
https://github.com/heartcombo/simple_form/issues/54#issuecomment-5600234