### PR TITLE
Removes immunity question from "volunteers" form

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -25,7 +25,6 @@ class VolunteersController < ApplicationController
       :name,
       :email,
       :phone,
-      :immunity,
       :about,
       :crew
     )

--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -65,12 +65,6 @@
     }
   %>
 
-  <%= f.input :immunity,
-    as: :radio_buttons,
-    :collection => [ ['Yes', true], ['No', false] ],
-    :checked => ['No', false]
-  %>
-
   <%= f.button :submit,
     t(".cta"),
     id: 'volunteer_submit',

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -19,7 +19,6 @@ en:
         name: 'Full name'
         email: 'Email address'
         phone: 'Phone number'
-        immunity: 'Do you have immunity against SARS-CoV-2?'
         about: 'About you'
     placeholders:
       defaults:

--- a/db/migrate/20200515133426_remove_immunity_column_from_volunteers_table.rb
+++ b/db/migrate/20200515133426_remove_immunity_column_from_volunteers_table.rb
@@ -1,0 +1,5 @@
+class RemoveImmunityColumnFromVolunteersTable < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :volunteers, :immunity, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_29_212730) do
+ActiveRecord::Schema.define(version: 2020_05_15_133426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 2020_03_29_212730) do
     t.string "name", null: false
     t.string "email", null: false
     t.string "phone", null: false
-    t.boolean "immunity", default: false, null: false
     t.text "about", null: false
     t.string "country"
     t.string "state"


### PR DESCRIPTION
As discussed in https://www.notion.so/Apply-Form-Remove-SARS-immunity-question-bb8c3053c82c4dee898ab78a3e13942e,
this diff removes the "SARS immunity" true/false question from the
"become a volunteer" form.

- drops the `immunity` col from `volunteer` table
- removes form helpers
- updates the view